### PR TITLE
Add Span#log_kv

### DIFF
--- a/lib/test/span.rb
+++ b/lib/test/span.rb
@@ -76,6 +76,10 @@ module Test
       @logs << LogEntry.new(event, timestamp, fields)
     end
 
+    def log_kv(*attributes)
+      log(*attributes)
+    end
+
     def finish(end_time: Time.now)
       Type! end_time, Time
       ensure_in_progress!

--- a/spec/test/span_spec.rb
+++ b/spec/test/span_spec.rb
@@ -142,6 +142,24 @@ RSpec.describe Test::Span do
       end
     end
 
+    describe :log_kv do
+      it "creates new log entry" do
+        span.log
+        expect(span.logs.size).to eq(1)
+      end
+
+      it "fills up log entries attributes properly" do
+        time = Time.now
+        span.log(event: "event", timestamp: time, additional: :info)
+        log = span.logs.last
+
+        expect(log).to be_instance_of(Test::Span::LogEntry)
+        expect(log.event).to eq("event")
+        expect(log.timestamp).to eq(time)
+        expect(log.fields).to eq(additional: :info)
+      end
+    end
+
     describe :finish do
       describe :in_progress? do
         it "is not in progress" do


### PR DESCRIPTION
Span#log has been deprecated for Span#log_kv:
https://github.com/opentracing/opentracing-ruby/blob/master/lib/opentracing/span.rb#L42-L60

I currently just forward the call to the existing #log method.