### PR TITLE
Upgrade opentracing dependency

### DIFF
--- a/test-tracer.gemspec
+++ b/test-tracer.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency 'opentracing', '~> 0.3.1'
+  spec.add_dependency 'opentracing', '~> 0.5.0'
 
   spec.add_development_dependency "bundler", "~> 1.15"
   spec.add_development_dependency "rake", "~> 10.0"


### PR DESCRIPTION
In the same spirit as https://github.com/iaintshine/ruby-grpc-opentracing/pull/6, this upgrades the `opentracing` dependency.