### PR TITLE
Update opentracing dependency to 0.5.0

### DIFF
--- a/lib/test/scope.rb
+++ b/lib/test/scope.rb
@@ -15,7 +15,7 @@ module Test
     # Return the Span scoped by this Scope
     #
     # @return [Span]
-    attr_reader :span
+    attr_reader :span, :finish_on_close, :scope_stack
 
     def closed?
       @closed
@@ -37,6 +37,7 @@ module Test
           "removed: #{removed_scope.inspect}, "\
           "expected: #{inspect}"
       end
+      removed_scope
     end
   end
 end

--- a/lib/test/scope.rb
+++ b/lib/test/scope.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+module Test
+  # Scope represents an OpenTracing Scope
+  #
+  # See http://www.opentracing.io for more information.
+  class Scope
+    def initialize(span, scope_stack, finish_on_close:)
+      @span = span
+      @scope_stack = scope_stack
+      @finish_on_close = finish_on_close
+      @closed = false
+    end
+
+    # Return the Span scoped by this Scope
+    #
+    # @return [Span]
+    attr_reader :span
+
+    def closed?
+      @closed
+    end
+
+    # Close scope
+    #
+    # Mark the end of the active period for the current thread and Scope,
+    # updating the ScopeManager#active in the process.
+    def close
+      raise "Tried to close already closed span: #{inspect}" if @closed
+      @closed = true
+
+      @span.finish if @finish_on_close
+      removed_scope = @scope_stack.pop
+
+      if removed_scope != self # rubocop:disable Style/GuardClause
+        raise 'Removed non-active scope, ' \
+          "removed: #{removed_scope.inspect}, "\
+          "expected: #{inspect}"
+      end
+    end
+  end
+end

--- a/lib/test/scope.rb
+++ b/lib/test/scope.rb
@@ -21,6 +21,7 @@ module Test
       @closed
     end
 
+    # OT complient
     # Close scope
     #
     # Mark the end of the active period for the current thread and Scope,

--- a/lib/test/scope_manager.rb
+++ b/lib/test/scope_manager.rb
@@ -17,6 +17,7 @@ module Test
       @scope_stack = ScopeStack.new
     end
 
+    # OT compliant
     # Make a span instance active
     #
     # @param span [Span] the Span that should become active
@@ -32,6 +33,7 @@ module Test
       scope
     end
 
+    # OT compliant
     # Return active scope
     #
     # If there is a non-null Scope, its wrapped Span becomes an implicit parent

--- a/lib/test/scope_manager.rb
+++ b/lib/test/scope_manager.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+require_relative 'scope_manager/scope_stack'
+
+module Test
+  # ScopeManager represents an OpenTracing ScopeManager
+  #
+  # See http://www.opentracing.io for more information.
+  #
+  # The ScopeManager interface abstracts both the activation of Span instances
+  # via ScopeManager#activate and access to an active Span/Scope via
+  # ScopeManager#active
+  class ScopeManager
+    def initialize
+      @scope_stack = ScopeStack.new
+    end
+
+    # Make a span instance active
+    #
+    # @param span [Span] the Span that should become active
+    # @param finish_on_close [Boolean] whether the Span should automatically be
+    #   finished when Scope#close is called
+    # @return [Scope] instance to control the end of the active period for the
+    #  Span. It is a programming error to neglect to call Scope#close on the
+    #  returned instance.
+    def activate(span, finish_on_close: true)
+      return active if active && active.span == span
+      scope = Scope.new(span, @scope_stack, finish_on_close: finish_on_close)
+      @scope_stack.push(scope)
+      scope
+    end
+
+    # Return active scope
+    #
+    # If there is a non-null Scope, its wrapped Span becomes an implicit parent
+    # (as Reference#CHILD_OF) of any newly-created Span at
+    # Tracer#start_active_span or Tracer#start_span time.
+    #
+    # @return [Scope] the currently active Scope which can be used to access the
+    #   currently active Span.
+    def active
+      @scope_stack.peek
+    end
+
+    def stack
+      @scope_stack.stack
+    end
+  end
+end

--- a/lib/test/scope_manager.rb
+++ b/lib/test/scope_manager.rb
@@ -11,6 +11,8 @@ module Test
   # via ScopeManager#activate and access to an active Span/Scope via
   # ScopeManager#active
   class ScopeManager
+    attr_reader :scope_stack
+
     def initialize
       @scope_stack = ScopeStack.new
     end
@@ -40,10 +42,6 @@ module Test
     #   currently active Span.
     def active
       @scope_stack.peek
-    end
-
-    def stack
-      @scope_stack.stack
     end
   end
 end

--- a/lib/test/scope_manager/scope_stack.rb
+++ b/lib/test/scope_manager/scope_stack.rb
@@ -24,7 +24,7 @@ module Test
       end
 
       def stack
-        Thread.current[@scope_identifier]
+        Thread.current[@scope_identifier].dup
       end
 
       private

--- a/lib/test/scope_manager/scope_stack.rb
+++ b/lib/test/scope_manager/scope_stack.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+module Test
+  class ScopeManager
+    # @api private
+    class ScopeStack
+      def initialize
+        # Generate a random identifier to use as the Thread.current key. This is
+        # needed so that it would be possible to create multiple tracers in one
+        # thread (mostly useful for testing purposes)
+        @scope_identifier = IdProvider.generate
+      end
+
+      def push(scope)
+        store << scope
+      end
+
+      def pop
+        store.pop
+      end
+
+      def peek
+        store.last
+      end
+
+      def stack
+        Thread.current[@scope_identifier]
+      end
+
+      private
+
+      def store
+        Thread.current[@scope_identifier] ||= []
+      end
+    end
+  end
+end

--- a/lib/test/span.rb
+++ b/lib/test/span.rb
@@ -2,13 +2,13 @@ module Test
   class Span < OpenTracing::Span
     class SpanAlreadyFinished < StandardError; end
 
-    class LogEntry < Struct.new(:event, :timestamp, :fields); end
+    class LogEntry < Struct.new(:timestamp, :fields); end
 
     include TypeCheck
 
-    attr_reader :tracer, :operation_name, :start_time, :end_time, :tags, :logs
+    attr_reader :tracer, :operation_name, :start_time, :end_time, :tags, :logs, :references
 
-    def initialize(tracer:, context:, operation_name:, start_time: Time.now, tags: nil)
+    def initialize(tracer:, context:, operation_name:, start_time: Time.now, references: [], tags: nil)
       Type! tracer, ::Test::Tracer
       Type! context, ::Test::SpanContext
       Type! operation_name, String
@@ -20,6 +20,7 @@ module Test
       @operation_name = operation_name
       @tags = tags || {}
       @logs = []
+      @references = references
       @start_time = start_time
       @end_time = nil
       @in_progress = true
@@ -59,21 +60,25 @@ module Test
       Type! value, String, NilClass
       ensure_in_progress!
 
-      @context.baggage[key] = value.to_s
+      @context.set_baggage_item(key, value)
       self
     end
 
     def get_baggage_item(key)
       Type! key, String
-      @context.baggage[key]
+      @context.get_baggage_item(key)
     end
 
-    def log(event: nil, timestamp: Time.now, **fields)
-      Type! event, String, NilClass
+    def log(**args)
+      Type! args, Hash, NilClass
+      ensure_in_progress!
+      log_kv(**args)
+    end
+
+    def log_kv(timestamp: Time.now, **fields)
       Type! timestamp, Time
       ensure_in_progress!
-
-      @logs << LogEntry.new(event, timestamp, fields)
+      @logs << LogEntry.new(timestamp, fields)
     end
 
     def finish(end_time: Time.now)

--- a/lib/test/span.rb
+++ b/lib/test/span.rb
@@ -14,6 +14,7 @@ module Test
       Type! operation_name, String
       Type! start_time, Time
       Type! tags, Hash, NilClass
+      Type! references, Array, NilClass
 
       @tracer = tracer
       @context = context

--- a/lib/test/span_context.rb
+++ b/lib/test/span_context.rb
@@ -32,6 +32,14 @@ module Test
       @baggage = baggage
     end
 
+    def set_baggage_item(key, value)
+      @baggage[key.to_s] = value.to_s
+    end
+
+    def get_baggage_item(key)
+      @baggage[key.to_s]
+    end
+
     def to_s
       "SpanContext(trace_id=#{trace_id}, span_id=#{span_id}, parent_span_id=#{parent_span_id}, baggage=#{baggage})"
     end

--- a/lib/test/tracer.rb
+++ b/lib/test/tracer.rb
@@ -126,9 +126,16 @@ module Test
     end
 
     # OT compliant
+    # active_span method it is implemented in OpenTracing tracer
+    # def active_span
+    #   scope = scope_manager.active
+    #   scope.span if scope
+    # end
+
+    # OT compliant
     def inject(span_context, format, carrier)
       NotNull! format
-      span_context = extract_span_context(span_context)
+      span_context = extract_wrapped_span_context(span_context)
 
       return unless carrier
 
@@ -168,7 +175,7 @@ module Test
         context_from_references(references) ||
         context_from_active_scope(ignore_active_scope)
 
-      context = extract_span_context(context)
+      context = extract_wrapped_span_context(context)
       if context
         ::Test::SpanContext.child_of(context)
       else
@@ -202,7 +209,7 @@ module Test
       active_scope.span.context if active_scope
     end
 
-    def extract_span_context(span_context)
+    def extract_wrapped_span_context(span_context)
       if Type?(span_context, ::Test::SpanContext, NilClass)
         span_context
       else

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,7 +1,6 @@
 require "bundler/setup"
 require "test-tracer"
 require "support/wrapping_tracer"
-require 'pry'
 
 RSpec.configure do |config|
   # Enable flags like --only-failures and --next-failure
@@ -12,5 +11,19 @@ RSpec.configure do |config|
 
   config.expect_with :rspec do |c|
     c.syntax = :expect
+  end
+
+  def build_span_context(opts = {})
+    Test::SpanContext.new({
+      trace_id: Test::IdProvider.generate,
+      span_id: Test::IdProvider.generate
+    }.merge(opts))
+  end
+
+  def build_span(tracer, opts = {})
+    span_context = opts.delete(:span_context) || build_span_context
+    operation_name = opts.delete(:operation_name) || 'operation-name'
+
+    Test::Span.new(tracer: tracer, context: span_context, operation_name: operation_name, **opts)
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,7 @@
 require "bundler/setup"
 require "test-tracer"
 require "support/wrapping_tracer"
+require 'pry'
 
 RSpec.configure do |config|
   # Enable flags like --only-failures and --next-failure

--- a/spec/test/scope_manager_spec.rb
+++ b/spec/test/scope_manager_spec.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Test::ScopeManager do
+  let(:scope_manager) { Test::ScopeManager.new }
+  let(:tracer) { Test::Tracer.new }
+  let(:span) { build_span(tracer) }
+
+  describe :activate do
+    it 'returns scope' do
+      scope = scope_manager.activate(span)
+      expect(scope).to be_instance_of(Test::Scope)
+    end
+
+    it 'propagates finish_on_close to scope' do
+      scope = scope_manager.activate(span, finish_on_close: false).close
+      expect(scope.closed?).to be_truthy
+      expect(scope.span.finished?).to be_falsey
+    end
+
+    it 'returns the same scope if it is active one' do
+      scope = scope_manager.activate(span)
+      the_same_scope = scope_manager.activate(span)
+      expect(scope_manager.scope_stack.stack.size).to eq(1)
+      expect(scope).to eq(the_same_scope)
+    end
+  end
+
+  describe :active do
+    let(:last_span) { build_span(tracer) }
+
+    it 'returns last activated element' do
+      scope_manager.activate(span)
+      last_scope = scope_manager.activate(last_span)
+      expect(scope_manager.active).to eq(last_scope)
+      expect(scope_manager.active.span).to eq(last_span)
+    end
+
+    it 'doesn\'t remove active scope' do
+      last_scope = scope_manager.activate(span)
+      expect(scope_manager.active).to eq(last_scope)
+      expect(scope_manager.active).to eq(last_scope)
+    end
+  end
+
+  describe :stack do
+    it 'allows to inspect whole scope stack' do
+      spans = Array.new(5) { |i| build_span(tracer, operation_name: "test_span_#{i}" )}
+      spans.each do |span|
+        scope_manager.activate(span)
+      end
+      expect(scope_manager.scope_stack.stack.first.span.operation_name).to eq(spans.first.operation_name)
+      expect(scope_manager.scope_stack.stack.map { |scope| scope.span.operation_name }).to eq(spans.map(&:operation_name))
+    end
+  end
+end

--- a/spec/test/scope_spec.rb
+++ b/spec/test/scope_spec.rb
@@ -1,0 +1,20 @@
+require "spec_helper"
+
+RSpec.describe Test::Scope do
+  describe :attributes do
+    let(:span_context) { Test::SpanContext.root }
+    let(:operation_name) { "span_name" }
+    let(:tracer) { Test::Tracer.new }
+    let(:span) { Test::Span.new(tracer: tracer, context: span_context, operation_name: operation_name) }
+    let(:scope) do
+      Test::Scope.new(span, span_context, finish_on_close: true)
+    end
+
+    it "returns proper for closed" do
+      expect(scope).to be
+    end
+  end
+
+  describe :root do
+  end
+end

--- a/spec/test/scope_spec.rb
+++ b/spec/test/scope_spec.rb
@@ -1,20 +1,64 @@
-require "spec_helper"
+# frozen_string_literal: true
+
+require 'spec_helper'
 
 RSpec.describe Test::Scope do
+  let(:operation_name) { 'span_name' }
+  let(:tracer) { Test::Tracer.new }
+  let(:scope_stack) { Test::ScopeManager::ScopeStack.new }
+  let(:span) { build_span(tracer) }
+
   describe :attributes do
-    let(:span_context) { Test::SpanContext.root }
-    let(:operation_name) { "span_name" }
-    let(:tracer) { Test::Tracer.new }
-    let(:span) { Test::Span.new(tracer: tracer, context: span_context, operation_name: operation_name) }
-    let(:scope) do
-      Test::Scope.new(span, span_context, finish_on_close: true)
+    let(:scope) { Test::Scope.new(span, scope_stack, finish_on_close: true) }
+
+    it 'returns proper value for closed' do
+      expect(scope.closed?).to be_falsey
     end
 
-    it "returns proper for closed" do
-      expect(scope).to be
+    it 'returns proper value for span' do
+      expect(scope.span).to eq(span)
     end
   end
 
-  describe :root do
+  describe :close do
+    let(:scope) { Test::Scope.new(span, scope_stack, finish_on_close: finish_on_close) }
+    let(:finish_on_close) { true }
+
+    before(:each) do
+      scope_stack.push(scope)
+    end
+
+    it 'throws error if some other scope is currently active' do
+      another_span = build_span(tracer)
+      another_scope = Test::Scope.new(another_span, scope_stack, finish_on_close: true)
+      scope_stack.push(another_scope)
+
+      expect { scope.close }.to raise_error(RuntimeError, /non-active/)
+    end
+
+    it 'removes self from scope stack' do
+      expect(scope.scope_stack.stack).to eq([scope])
+      scope.close
+      expect(scope.scope_stack.stack).to eq([])
+    end
+
+    context 'finished on close is true' do
+      let(:finish_on_close) { true }
+      it 'closes the scope with span' do
+        scope.close
+        expect(scope.closed?).to be_truthy
+        expect(scope.span.finished?).to be_truthy
+      end
+    end
+
+    context 'finished on close is false' do
+      let(:finish_on_close) { false }
+
+      it 'closes the scope and keeps the span opened' do
+        scope.close
+        expect(scope.closed?).to be_truthy
+        expect(scope.span.in_progress?).to be_truthy
+      end
+    end
   end
 end

--- a/spec/test/span_spec.rb
+++ b/spec/test/span_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe Test::Span do
   let(:tracer) { Test::Tracer.new }
   let(:span_context) { Test::SpanContext.root }
   let(:operation_name) { "span_name" }
-  let(:span) { Test::Span.new(tracer: tracer, context: span_context, operation_name: operation_name) }
+  let(:span) { build_span(tracer, operation_name: operation_name, span_context: span_context) }
 
   describe :initialize do
     describe :in_progress? do
@@ -30,6 +30,22 @@ RSpec.describe Test::Span do
       it "returns start_time from initialization" do
         time = Time.now - 60
         expect(Test::Span.new(tracer: tracer, context: span_context, operation_name: operation_name, start_time: time).start_time).to eq(time)
+      end
+    end
+
+     describe :references do
+      it "returns references from initialization" do
+        open_tracing_references = Array.new(3) { OpenTracing::Reference.child_of(build_span_context) }
+
+        span = Test::Span.new(
+          tracer: tracer,
+          context: span_context,
+          operation_name: operation_name,
+          references: open_tracing_references
+        )
+        expect(span.references).to be_instance_of(Array)
+        expect(span.references.first).to be_instance_of(OpenTracing::Reference)
+        expect(span.references).to eq(open_tracing_references)
       end
     end
   end
@@ -89,7 +105,7 @@ RSpec.describe Test::Span do
 
       it "sets a baggage on context" do
         span.set_baggage_item("key", "value")
-        expect(span.context.baggage["key"]).to eq("value")
+        expect(span.context.get_baggage_item("key")).to eq("value")
       end
 
       it "allows string only keys" do
@@ -156,7 +172,7 @@ RSpec.describe Test::Span do
 
         expect(log).to be_instance_of(Test::Span::LogEntry)
         expect(log.timestamp).to eq(time)
-        expect(log.fields).to eq(additional: :info, :something=>:else)
+        expect(log.fields).to eq(additional: :info, something: :else)
       end
     end
 

--- a/spec/test/span_spec.rb
+++ b/spec/test/span_spec.rb
@@ -131,14 +131,32 @@ RSpec.describe Test::Span do
       end
 
       it "fills up log entries attributes properly" do
+        event_name = "event"
         time = Time.now
-        span.log(event: "event", timestamp: time, additional: :info)
+        span.log(event: event_name, timestamp: time, additional: :info)
         log = span.logs.last
 
         expect(log).to be_instance_of(Test::Span::LogEntry)
-        expect(log.event).to eq("event")
+        expect(log.fields[:event]).to eq(event_name)
         expect(log.timestamp).to eq(time)
-        expect(log.fields).to eq(additional: :info)
+        expect(log.fields).to eq(additional: :info, event: event_name)
+      end
+    end
+
+    describe :log_kv do
+      it "creates new log entry" do
+        span.log_kv
+        expect(span.logs.size).to eq(1)
+      end
+
+      it "fills up log entries attributes properly" do
+        time = Time.now
+        span.log_kv(timestamp: time, additional: :info, something: :else)
+        log = span.logs.last
+
+        expect(log).to be_instance_of(Test::Span::LogEntry)
+        expect(log.timestamp).to eq(time)
+        expect(log.fields).to eq(additional: :info, :something=>:else)
       end
     end
 

--- a/spec/test/tracer_spec.rb
+++ b/spec/test/tracer_spec.rb
@@ -9,6 +9,21 @@ RSpec.describe Test::Tracer do
     it "has no finished spans" do
       expect(Test::Tracer.new.finished_spans).to be_empty
     end
+
+    it 'has ready scope manager with empty scope stack' do
+      tracer = Test::Tracer.new
+      expect(tracer.scope_manager).to be_instance_of(Test::ScopeManager)
+      expect(tracer.scope_manager.active).to be_nil
+    end
+  end
+
+  describe 'active_span' do
+    it 'returns correct scope' do
+      tracer = Test::Tracer.new
+      span = tracer.start_span("span")
+      tracer.scope_manager.activate(span)
+      expect(tracer.active_span).to eq(span)
+    end
   end
 
   describe :start_span do
@@ -39,12 +54,23 @@ RSpec.describe Test::Tracer do
     end
 
     it 'works corretly with passed in block' do
-      value = tracer.start_span("test") do |span|
+      return_value = 'expected_value'
+      block_value = tracer.start_span("test") do |span|
         expect(span).to be_instance_of(Test::Span)
-        'expected_value'
+        return_value
       end
+      expect(block_value).to eq(return_value)
+    end
 
-      expect(value).to eq('expected_value')
+    describe "references propagation" do
+      it "sets references on newly created span" do
+        parent_context = build_span_context
+        reference = OpenTracing::Reference.child_of(parent_context)
+        span = tracer.start_span("test_span", references: [reference])
+        expect(span.references.size).to eq(1)
+        expect(span.context.parent_span_id).to eq(parent_context.span_id)
+        expect(span.references.first.context).to eq(parent_context)
+      end
     end
 
     describe "context propagation" do
@@ -67,6 +93,36 @@ RSpec.describe Test::Tracer do
         expect(child_span.context.trace_id).to eq(root_span_context.trace_id)
         expect(child_span.context.parent_span_id).to eq(root_span_context.span_id)
       end
+
+      describe 'active scope propagation' do
+        context 'no active span is present' do
+          it "creates separate root parants if there is no parent and no active span" do
+            root_span = tracer.start_span("root")
+            another_root_span = tracer.start_span("another_root")
+
+            expect(root_span.context.parent_span_id).to be_nil
+            expect(another_root_span.context.parent_span_id).to be_nil
+          end
+        end
+
+        context 'active span is present' do
+          let(:root_span) { build_span(tracer, operation_name: "root") }
+
+          before(:each) do
+            tracer.scope_manager.activate(root_span)
+          end
+
+          it "creates span and sets its parent span to active span" do
+            span = tracer.start_span("test_span")
+            expect(span.context.parent_span_id).to eq(root_span.context.span_id)
+          end
+
+          it "ignore active span if specified by ignore_active_scope" do
+            span = tracer.start_span("test_span", ignore_active_scope: true)
+            expect(span.context.parent_span_id).to be_nil
+          end
+        end
+      end
     end
 
     describe :spans do
@@ -74,16 +130,6 @@ RSpec.describe Test::Tracer do
         span = tracer.start_span("span")
 
         expect(tracer.spans.size).to eq(1)
-        expect(tracer.spans.first).to eq(span)
-      end
-
-      it 'adds newely started span to spans collection with block' do
-        span = tracer.start_span("span") do |span|
-          span
-        end
-
-        expect(tracer.spans.size).to eq(1)
-        expect(tracer.finished_spans.size).to eq(1)
         expect(tracer.spans.first).to eq(span)
       end
     end
@@ -96,6 +142,13 @@ RSpec.describe Test::Tracer do
       end
 
       context "on span finish" do
+        it 'automatically finish span if start_span received block' do
+          returned_span = tracer.start_span("span") { |span| span }
+
+          expect(tracer.finished_spans.size).to eq(1)
+          expect(tracer.finished_spans.first).to eq(returned_span)
+        end
+
         it "adds finished span to finished_spans collection" do
           span = tracer.start_span("span").finish
 
@@ -104,30 +157,193 @@ RSpec.describe Test::Tracer do
         end
       end
     end
+
+    describe 'scope_manager scope stack' do
+      it "start_span doesn't add to scope stack" do
+        tracer.start_span("span")
+        expect(tracer.scope_manager).to be_instance_of(Test::ScopeManager)
+        expect(tracer.scope_manager.scope_stack.stack).to eq([])
+        expect(tracer.scope_manager.active).to be_nil
+      end
+    end
   end
 
-  # describe :start_active_span do
-  #   let(:tracer) { Test::Tracer.new }
+  describe :start_active_span do
+    let(:tracer) { Test::Tracer.new }
 
-  #   it "returns instance of Scope" do
-  #     expect(tracer.start_active_span("test")).to be_instance_of(Test::Scope)
-  #   end
+    it "returns instance of Scope" do
+      expect(tracer.start_active_span('root')).to be_instance_of(Test::Scope)
+    end
 
-  #   describe "operation_name propagation" do
-  #     it "sets operation_name on newly created span" do
-  #       expect(tracer.start_active_span("test").operation_name).to eq("test")
-  #     end
-  #   end
+    describe "operation_name propagation" do
+      it "sets operation_name on newly created span" do
+        expect(tracer.start_active_span("test").span.operation_name).to eq("test")
+      end
+    end
 
-  #   describe "tags propagation" do
-  #     it "sets tags on newly created span" do
-  #       tags = { 'span.kind' => 'client' }
-  #       expect(tracer.start_active_span("test", tags: tags).tags).to eq(tags)
-  #     end
-  #   end
+    describe "tags propagation" do
+      it "sets tags on newly created span" do
+        tags = { 'span.kind' => 'client' }
+        expect(tracer.start_active_span("test", tags: tags).span.tags).to eq(tags)
+      end
+    end
 
+    describe "start_time propagation" do
+      it "sets start_time on newly created span" do
+        time = Time.now - 60
+        expect(tracer.start_active_span("test", start_time: time).span.start_time).to eq(time)
+      end
+    end
 
-  # end
+    it 'works corretly with passed in block' do
+      return_value = 'expected_value'
+      block_value = tracer.start_active_span("test") do |scope|
+        expect(scope).to be_instance_of(Test::Scope)
+        return_value
+      end
+      expect(block_value).to eq(return_value)
+    end
+
+    describe 'scope_manager scope stack' do
+      it "adds to scope stack" do
+        scope = tracer.start_active_span('test')
+        expect(scope.closed?).to be_falsey
+        expect(tracer.scope_manager.scope_stack.stack).to eq([scope])
+        expect(tracer.active_span).to eq(scope.span)
+      end
+
+      it 'adds and removes active scope to scope stack for brief moment if start_active_span received block' do
+        returned_scope = tracer.start_active_span('test') do |scope|
+          expect(tracer.active_span).to eq(scope.span)
+          expect(scope.closed?).to be_falsey
+          scope
+        end
+
+        expect(returned_scope.closed?).to be_truthy
+        expect(tracer.active_span).to be_nil
+      end
+
+      it 'nests correctly' do
+        tracer.start_active_span('parent_span') do |parent_scope|
+          expect(tracer.active_span).to eq(parent_scope.span)
+          tracer.start_active_span('child_span') do |child_scope|
+            expect(tracer.active_span).to eq(child_scope.span)
+            expect(tracer.scope_manager.scope_stack.stack).to eq([parent_scope, child_scope])
+            expect(child_scope.span.context.parent_span_id).to eq(parent_scope.span.context.span_id)
+          end
+        end
+      end
+    end
+
+    describe "references propagation" do
+      it "sets references on newly created span" do
+        parent_context = build_span_context
+        reference = OpenTracing::Reference.child_of(parent_context)
+        scope = tracer.start_active_span("test_span", references: [reference])
+        expect(scope.span.references.size).to eq(1)
+        expect(scope.span.context.parent_span_id).to eq(parent_context.span_id)
+        expect(scope.span.references.first.context).to eq(parent_context)
+      end
+    end
+
+    describe 'finish_on_close propagation' do
+      it 'sets finish_on_close in new scope' do
+        expect(tracer.start_active_span("test_span", finish_on_close: false).finish_on_close).to be_falsey
+      end
+    end
+
+    describe "context propagation" do
+      it "creates new root context when no parent context passed" do
+        expect(tracer.start_active_span("root").span.context.parent_span_id).to be_nil
+      end
+
+      it "propagates parent context when parent span passed" do
+        root_scope = tracer.start_active_span("root")
+        child_scope = tracer.start_active_span("child", child_of: root_scope.span)
+
+        expect(child_scope.span.context.trace_id).to eq(root_scope.span.context.trace_id)
+        expect(child_scope.span.context.parent_span_id).to eq(root_scope.span.context.span_id)
+      end
+
+      it "propagates parent context when parent span context passed" do
+        root_scope = tracer.start_active_span("root")
+        child_scope = tracer.start_active_span("child", child_of: root_scope.span.context)
+
+        expect(child_scope.span.context.trace_id).to eq(root_scope.span.context.trace_id)
+        expect(child_scope.span.context.parent_span_id).to eq(root_scope.span.context.span_id)
+      end
+
+      describe 'active scope propagation' do
+        context 'no active span is present' do
+          it "creates separete root parants if there is no parent and no active span" do
+            scope = tracer.start_active_span("child")
+            expect(scope.span.context.parent_span_id).to be_nil
+            expect(tracer.active_span).to eq(scope.span)
+          end
+        end
+
+        context 'active span is present' do
+          it "creates span and sets its parent span to active span" do
+            parent_scope = tracer.start_active_span('root')
+            child_scope = tracer.start_active_span("child")
+            expect(child_scope.span.context.parent_span_id).to eq(parent_scope.span.context.span_id)
+          end
+
+          it "ignore active span if specified by ignore_active_scope" do
+            tracer.start_active_span('root')
+            child_scope = tracer.start_active_span("child", ignore_active_scope: true)
+            expect(child_scope.span.context.parent_span_id).to be_nil
+          end
+        end
+      end
+    end
+
+    describe :spans do
+      let(:scope_stack) { tracer.scope_manager.scope_stack }
+
+      it "adds newely started span to spans collection" do
+        span = tracer.start_active_span("test_span").span
+
+        expect(tracer.spans.size).to eq(1)
+        expect(tracer.spans.first).to eq(span)
+        expect(scope_stack.stack.size).to eq(1)
+        expect(scope_stack.stack.first.span).to eq(span)
+      end
+    end
+
+    describe :finished_spans do
+      let(:scope_stack) { tracer.scope_manager.scope_stack }
+
+      it "doesn\'t add newely started active span to finished_spans collection" do
+        span = tracer.start_active_span("span").span
+
+        expect(scope_stack.stack.size).to eq(1)
+        expect(scope_stack.stack.first.span).to eq(span)
+        expect(tracer.finished_spans).to be_empty
+      end
+
+      context "on span finish" do
+        it "automatically finish span if start_active_span received block" do
+          span = tracer.start_active_span("span") do |scope|
+            scope.span
+          end
+
+          expect(scope_stack.stack.size).to eq(0)
+          expect(tracer.active_span).to be_nil
+          expect(tracer.finished_spans.size).to eq(1)
+          expect(tracer.finished_spans.first).to eq(span)
+        end
+
+        it "adds finished span to finished_spans collection" do
+          scope = tracer.start_active_span("span").close
+
+          expect(tracer.active_span).to be_nil
+          expect(tracer.finished_spans.size).to eq(1)
+          expect(tracer.finished_spans.first).to eq(scope.span)
+        end
+      end
+    end
+  end
 
   describe :inject do
     let(:tracer) { Test::Tracer.new }

--- a/spec/test/tracer_spec.rb
+++ b/spec/test/tracer_spec.rb
@@ -38,6 +38,15 @@ RSpec.describe Test::Tracer do
       end
     end
 
+    it 'works corretly with passed in block' do
+      value = tracer.start_span("test") do |span|
+        expect(span).to be_instance_of(Test::Span)
+        'expected_value'
+      end
+
+      expect(value).to eq('expected_value')
+    end
+
     describe "context propagation" do
       it "creates new root context when no parent context passed" do
         expect(tracer.start_span("root").context.parent_span_id).to eq(nil)
@@ -67,6 +76,16 @@ RSpec.describe Test::Tracer do
         expect(tracer.spans.size).to eq(1)
         expect(tracer.spans.first).to eq(span)
       end
+
+      it 'adds newely started span to spans collection with block' do
+        span = tracer.start_span("span") do |span|
+          span
+        end
+
+        expect(tracer.spans.size).to eq(1)
+        expect(tracer.finished_spans.size).to eq(1)
+        expect(tracer.spans.first).to eq(span)
+      end
     end
 
     describe :finished_spans do
@@ -86,6 +105,29 @@ RSpec.describe Test::Tracer do
       end
     end
   end
+
+  # describe :start_active_span do
+  #   let(:tracer) { Test::Tracer.new }
+
+  #   it "returns instance of Scope" do
+  #     expect(tracer.start_active_span("test")).to be_instance_of(Test::Scope)
+  #   end
+
+  #   describe "operation_name propagation" do
+  #     it "sets operation_name on newly created span" do
+  #       expect(tracer.start_active_span("test").operation_name).to eq("test")
+  #     end
+  #   end
+
+  #   describe "tags propagation" do
+  #     it "sets tags on newly created span" do
+  #       tags = { 'span.kind' => 'client' }
+  #       expect(tracer.start_active_span("test", tags: tags).tags).to eq(tags)
+  #     end
+  #   end
+
+
+  # end
 
   describe :inject do
     let(:tracer) { Test::Tracer.new }

--- a/test-tracer.gemspec
+++ b/test-tracer.gemspec
@@ -24,9 +24,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'opentracing', '~> 0.3.1'
 
-
   spec.add_development_dependency "bundler", "~> 1.15"
-  spec.add_development_dependency "pry-byebug"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.0"
 end

--- a/test-tracer.gemspec
+++ b/test-tracer.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency 'opentracing', '~> 0.3.1'
+  spec.add_dependency 'opentracing', '~> 0.5.0'
 
   spec.add_development_dependency "bundler", "~> 1.15"
   spec.add_development_dependency "rake", "~> 10.0"

--- a/test-tracer.gemspec
+++ b/test-tracer.gemspec
@@ -24,7 +24,9 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'opentracing', '~> 0.3.1'
 
+
   spec.add_development_dependency "bundler", "~> 1.15"
+  spec.add_development_dependency "pry-byebug"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.0"
 end


### PR DESCRIPTION
I have updated OpenTracing dependencies to `0.5.0`. 

OpenTracing API has changed since version `0.3.2` - you can check [Git diff](https://github.com/opentracing/opentracing-ruby/compare/69b779737c0414ab47fe59773887191b23c5ffcd...master) but these are the most notable changes: 

* `Tracer#start_active_span` - return `Test::Scope` and adds this scope to ScopeManager's stack
* `Tracer#start_span` can now accepts block
* Addition of `Test::ScopeManager` - scope manager keeps track of active span (with stack) tracer can access it with `Tracer#scope_manager`
* Addition of `Test::Scope` - scope encapsulate span
* `Tracer#active_span` - now returns active span - top of `ScopeStack`
* `Span#log` is now depracated in favour of `Span#log_kv`

I have added some useful public method/accessors to each new class.  and also references attribute to `Test::Span` to be compatible with API. 

These new changes should not break the basic idea of this tracer to record all spans in memory. You can now also inspect the current scope stack of the tracer. 

The new parts are heavily influenced by [Jaeger ruby client](https://github.com/salemove/jaeger-client-ruby).

Please take a look if the tests are sufficient 📗 

Refs #19 
