### PR TITLE
Loosen opentracing constraint

### DIFF
--- a/test-tracer.gemspec
+++ b/test-tracer.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency 'opentracing', '~> 0.3.1'
+  spec.add_dependency 'opentracing', '~> 0.3'
 
   spec.add_development_dependency "bundler", "~> 1.15"
   spec.add_development_dependency "rake", "~> 10.0"


### PR DESCRIPTION
For projects which use `rack-tracer` and `grpc-opentracing`, bundler cannot install because the `opentracing` gem constraints are incompatible (reproduced below). Since this gem is a dependency of `grpc-opentracing`, it has to be massaged before `grpc-opentracing` can be.
All tests pass on `opentracing` 0.5.

```
Resolving dependencies...
Bundler could not find compatible versions for gem "opentracing":
  In snapshot (Gemfile.lock):
    opentracing (= 0.5.0)

  In Gemfile:
    grpc-opentracing was resolved to 1.0.0, which depends on
      method-tracer (~> 1.1) was resolved to 1.1.2, which depends on
        opentracing (~> 0.3.1)

    rack-tracer was resolved to 0.9.0, which depends on
      opentracing (~> 0.4)

Running `bundle update` will rebuild your snapshot from scratch, using only
the gems in your Gemfile, which may resolve the conflict.
```